### PR TITLE
feat(google_secret): Add google secret manager handler

### DIFF
--- a/jans/pycloudlib/config/__init__.py
+++ b/jans/pycloudlib/config/__init__.py
@@ -1,2 +1,3 @@
 from jans.pycloudlib.config.consul_config import ConsulConfig  # noqa: F401
 from jans.pycloudlib.config.kubernetes_config import KubernetesConfig  # noqa: F401
+from jans.pycloudlib.config.google_config import GoogleConfig  # noqa: F401

--- a/jans/pycloudlib/config/base_config.py
+++ b/jans/pycloudlib/config/base_config.py
@@ -30,8 +30,22 @@ class BaseConfig:
         """
         raise NotImplementedError
 
-    def all(self) -> NoReturn:
-        """Get all config.
+    def all(self) -> NoReturn:  # pragma: no cover
+        """Get all config (deprecated in favor of ``get_all``).
+
+        Subclass **MUST** implement this method.
+        """
+        return self.get_all()
+
+    def set_all(self, data: dict) -> NoReturn:
+        """Set all config.
+
+        Subclass **MUST** implement this method.
+        """
+        raise NotImplementedError
+
+    def get_all(self) -> NoReturn:
+        """Get all secrets.
 
         Subclass **MUST** implement this method.
         """

--- a/jans/pycloudlib/config/google_config.py
+++ b/jans/pycloudlib/config/google_config.py
@@ -28,16 +28,15 @@ class GoogleConfig(BaseConfig):
 
     - ``GOOGLE_APPLICATION_CREDENTIALS`` json file that should be injected in upstream images
     - ``GOOGLE_PROJECT_ID``
-    - ``CN_GOOGLE_SECRET_VERSION_ID``
-    - ``CN_GOOGLE_SECRET_MANAGER_PASSPHRASE``
-    - ``CN_SECRET_GOOGLE_SECRET``
+    - ``CN_CONFIG_GOOGLE_SECRET_VERSION_ID``
+    - ``CN_CONFIG_GOOGLE_SECRET_NAME_PREFIX``
     """
 
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_PROJECT_ID")
-        self.version_id = os.getenv("CN_GOOGLE_SECRET_VERSION_ID", "latest")
+        self.version_id = os.getenv("CN_CONFIG_GOOGLE_SECRET_VERSION_ID", "latest")
         # secrets key value by default
-        self.google_secret_name = os.getenv("CN_SECRET_GOOGLE_SECRET", "jans") + "-configuration"
+        self.google_secret_name = os.getenv("CN_CONFIG_GOOGLE_SECRET_NAME_PREFIX", "jans") + "-configuration"
         # Create the Secret Manager client.
         self.client = secretmanager.SecretManagerServiceClient()
 

--- a/jans/pycloudlib/config/google_config.py
+++ b/jans/pycloudlib/config/google_config.py
@@ -100,7 +100,6 @@ class GoogleConfig(BaseConfig):
         logger.info(f'Adding key {key} to google secret manager')
         logger.info(f'Size of secret payload : {sys.getsizeof(safe_value(all_))} bytes')
         secret_version_bool = self.add_secret_version(safe_value(all_))
-        logger.info(secret_version_bool)
         return secret_version_bool
 
     def set_all(self, data: dict) -> bool:

--- a/jans/pycloudlib/manager.py
+++ b/jans/pycloudlib/manager.py
@@ -59,12 +59,26 @@ class ConfigManager:
         """
         return self.adapter.set(key, value)
 
-    def all(self) -> dict:
+    def all(self) -> dict:  # noqa: A003
+        """Get all key-value pairs (deprecated in favor of ``get_all``).
+
+        :returns: A ``dict`` of key-value pairs (if any).
+        """
+        return self.get_all()
+
+    def get_all(self) -> dict:
         """Get all key-value pairs.
 
         :returns: A ``dict`` of key-value pairs (if any).
         """
-        return {k: v for k, v in self.adapter.all().items()}
+        return self.adapter.get_all()
+
+    def set_all(self, data: dict) -> bool:
+        """Set all key-value pairs.
+
+        :params data: Key-value pairs.
+        """
+        return self.adapter.set_all(data)
 
 
 class SecretManager:
@@ -107,11 +121,25 @@ class SecretManager:
         return self.adapter.set(key, value)
 
     def all(self) -> dict:  # noqa: A003
+        """Get all key-value pairs (deprecated in favor of ``get_all``).
+
+        :returns: A ``dict`` of key-value pairs (if any).
+        """
+        return self.get_all()
+
+    def get_all(self) -> dict:
         """Get all key-value pairs.
 
         :returns: A ``dict`` of key-value pairs (if any).
         """
-        return self.adapter.all()
+        return self.adapter.get_all()
+
+    def set_all(self, data: dict) -> bool:
+        """Set all key-value pairs.
+
+        :params data: Key-value pairs.
+        """
+        return self.adapter.set_all(data)
 
     def to_file(
         self, key: str, dest: str, decode: bool = False, binary_mode: bool = False
@@ -217,7 +245,7 @@ def get_manager() -> NamedTuple:
     """Convenient function to get config and secret manager instances.
 
     :returns: A ``namedtuple`` consists of :class:`~jans.pycloudlib.manager.ConfigManager`
-              and :class:`~jans.pycloudlib.manager.SecretManager` instances.
+        and :class:`~jans.pycloudlib.manager.SecretManager` instances.
     """
     config_mgr = ConfigManager()
     secret_mgr = SecretManager()

--- a/jans/pycloudlib/manager.py
+++ b/jans/pycloudlib/manager.py
@@ -13,6 +13,7 @@ from typing import NamedTuple
 
 from jans.pycloudlib.config import ConsulConfig
 from jans.pycloudlib.config import KubernetesConfig
+from jans.pycloudlib.config import GoogleConfig
 from jans.pycloudlib.secret import KubernetesSecret
 from jans.pycloudlib.secret import VaultSecret
 from jans.pycloudlib.secret import GoogleSecret
@@ -27,7 +28,7 @@ class ConfigManager:
 
     - :class:`~jans.pycloudlib.config.consul_config.ConsulConfig`
     - :class:`~jans.pycloudlib.config.kubernetes_config.KubernetesConfig`
-    - :class:`~jans.pycloudlib.secret.google_secret.GoogleSecret`
+    - :class:`~jans.pycloudlib.secret.google_config.GoogleConfig`
     """
     def __init__(self):
         _adapter = os.environ.get("CN_CONFIG_ADAPTER", "consul",)
@@ -36,7 +37,7 @@ class ConfigManager:
         elif _adapter == "kubernetes":
             self.adapter = KubernetesConfig()
         elif _adapter == "google":
-            self.adapter = GoogleSecret(configuration=True)
+            self.adapter = GoogleConfig()
         else:
             self.adapter = None
 

--- a/jans/pycloudlib/manager.py
+++ b/jans/pycloudlib/manager.py
@@ -15,6 +15,7 @@ from jans.pycloudlib.config import ConsulConfig
 from jans.pycloudlib.config import KubernetesConfig
 from jans.pycloudlib.secret import KubernetesSecret
 from jans.pycloudlib.secret import VaultSecret
+from jans.pycloudlib.secret import GoogleSecret
 from jans.pycloudlib.utils import decode_text
 from jans.pycloudlib.utils import encode_text
 
@@ -26,6 +27,7 @@ class ConfigManager:
 
     - :class:`~jans.pycloudlib.config.consul_config.ConsulConfig`
     - :class:`~jans.pycloudlib.config.kubernetes_config.KubernetesConfig`
+    - :class:`~jans.pycloudlib.secret.google_secret.GoogleSecret`
     """
     def __init__(self):
         _adapter = os.environ.get("CN_CONFIG_ADAPTER", "consul",)
@@ -33,6 +35,8 @@ class ConfigManager:
             self.adapter = ConsulConfig()
         elif _adapter == "kubernetes":
             self.adapter = KubernetesConfig()
+        elif _adapter == "google":
+            self.adapter = GoogleSecret(configuration=True)
         else:
             self.adapter = None
 
@@ -69,6 +73,7 @@ class SecretManager:
 
     - :class:`~jans.pycloudlib.secret.vault_secret.VaultSecret`
     - :class:`~jans.pycloudlib.secret.kubernetes_secret.KubernetesSecret`
+    - :class:`~jans.pycloudlib.secret.google_secret.GoogleSecret`
     """
 
     def __init__(self):
@@ -77,6 +82,8 @@ class SecretManager:
             self.adapter = VaultSecret()
         elif _adapter == "kubernetes":
             self.adapter = KubernetesSecret()
+        elif _adapter == "google":
+            self.adapter = GoogleSecret()
         else:
             self.adapter = None
 

--- a/jans/pycloudlib/secret/__init__.py
+++ b/jans/pycloudlib/secret/__init__.py
@@ -1,2 +1,3 @@
 from jans.pycloudlib.secret.kubernetes_secret import KubernetesSecret  # noqa: F401
 from jans.pycloudlib.secret.vault_secret import VaultSecret  # noqa: F401
+from jans.pycloudlib.secret.google_secret import GoogleSecret # noqa: F401

--- a/jans/pycloudlib/secret/base_secret.py
+++ b/jans/pycloudlib/secret/base_secret.py
@@ -9,7 +9,7 @@ from typing import Any
 from typing import NoReturn
 
 
-class BaseSecret(object):
+class BaseSecret:
     """Base class for secret adapter. Must be sub-classed per
     implementation details.
     """
@@ -30,7 +30,21 @@ class BaseSecret(object):
         """
         raise NotImplementedError
 
-    def all(self) -> NoReturn:
+    def all(self) -> NoReturn:  # pragma: no cover
+        """Get all secrets (deprecated in favor of ``get_all``).
+
+        Subclass **MUST** implement this method.
+        """
+        return self.get_all()
+
+    def set_all(self, data: dict) -> NoReturn:
+        """Set all secrets.
+
+        Subclass **MUST** implement this method.
+        """
+        raise NotImplementedError
+
+    def get_all(self) -> NoReturn:
         """Get all secrets.
 
         Subclass **MUST** implement this method.

--- a/jans/pycloudlib/secret/google_secret.py
+++ b/jans/pycloudlib/secret/google_secret.py
@@ -1,0 +1,208 @@
+"""
+jans.pycloudlib.secret.google_secret
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains secret adapter class to interact with
+Kubernetes Secret.
+"""
+
+import hashlib
+import sys
+import os
+import json
+from binascii import hexlify, unhexlify
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.exceptions import InvalidTag
+from typing import Any
+
+from google.cloud import secretmanager
+from google.api_core.exceptions import AlreadyExists, NotFound
+from jans.pycloudlib.secret.base_secret import BaseSecret
+from jans.pycloudlib.utils import safe_value
+import lzma
+import zlib
+
+
+class GoogleSecret(BaseSecret):
+    """This class interacts with Kubernetes Secret backend.
+
+    The following environment variables are used to instantiate the client:
+
+    - ``GOOGLE_APPLICATION_CREDENTIALS`` json file that should be injected in upstream images
+    - ``GOOGLE_PROJECT_ID``
+    - ``CN_GOOGLE_SECRET_VERSION_ID``
+    - ``CN_GOOGLE_SECRET_MANAGER_PASSPHRASE``
+    - ``CN_SECRET_GOOGLE_SECRET``
+    """
+
+    def __init__(self, configuration=False):
+        self.project_id = os.getenv("GOOGLE_PROJECT_ID")
+        self.version_id = os.getenv("CN_GOOGLE_SECRET_VERSION_ID", "latest")
+        self.salt = os.urandom(16)
+        self.passphrase = os.getenv("CN_GOOGLE_SECRET_MANAGER_PASSPHRASE", "secret")
+        # secrets key valye by default
+        self.google_secret_name = os.getenv("CN_SECRET_GOOGLE_SECRET", "jans") + "-secret"
+        if configuration:
+            self.google_secret_name = os.getenv("CN_SECRET_GOOGLE_SECRET", "jans") + "-configuration"
+        # Create the Secret Manager client.
+        self.client = secretmanager.SecretManagerServiceClient()
+        self.key = self._set_key()
+
+    def _set_key(self) -> bytes:
+        """
+        Return key for for encrypting and decrypting payload
+        :return: key
+        """
+        return hashlib.pbkdf2_hmac("sha256", self.passphrase.encode("utf8"), self.salt, 1000)
+
+    def _encrypt(self, plaintext: str) -> str:
+        """
+        Encrypt payload
+        :oarans plaintext: plain string to encrypt
+        :return: A string including salr, iv, and encrypted payload
+        """
+        aes = AESGCM(self.key)
+        iv = os.urandom(16)
+        plaintext = plaintext.encode("utf8")
+        plaintext = lzma.compress(plaintext)
+        ciphertext = aes.encrypt(iv, plaintext, None)
+        print(f'Size of encrypted secret payload : {sys.getsizeof(ciphertext)} bytes')
+        return "%s-%s-%s" % (
+            hexlify(self.salt).decode("utf8"), hexlify(iv).decode("utf8"), hexlify(ciphertext).decode("utf8"))
+
+    def _decrypt(self, ciphertext: str) -> str:
+        """
+        Decrypt payload
+        :params ciphertext: encrypted string to decrypt
+        :return: decrypted payload
+        """
+        self.salt, iv, ciphertext = map(unhexlify, ciphertext.split("-"))
+        self.key = self._set_key()
+        aes = AESGCM(self.key)
+        plaintext = ""
+        try:
+            plaintext = aes.decrypt(iv, ciphertext, None)
+            plaintext = lzma.decompress(plaintext)
+        except InvalidTag:
+            print("Wrong passphrase used.")
+        return plaintext.decode("utf8")
+
+    def all(self) -> dict:
+        """
+        Access the payload for the given secret version if one exists. The version
+        can be a version number as a string (e.g. "5") or an alias (e.g. "latest").
+        :returns: A ``dict`` of key-value pairs (if any)
+        """
+        # Build the resource name of the secret version.
+        name = f"projects/{self.project_id}/secrets/{self.google_secret_name}/versions/{self.version_id}"
+        data = {}
+        retry = False
+        while retry:
+            try:
+                # Access the secret version.
+                response = self.client.access_secret_version(request={"name": name})
+                print(f"Secret {self.google_secret_name} has been found. Accessing version {self.version_id}.")
+                payload = zlib.decompress(response.payload.data).decode("UTF-8")
+                data = json.loads(self._decrypt(payload))
+                retry = False
+            except NotFound:
+                print("Secret may not exist or have any versions created")
+                self.create_secret()
+                self.add_secret_version(self._encrypt(safe_value({})))
+                retry = True
+
+        return data
+
+    def get(self, key, default: Any = None) -> Any:
+        """Get value based on given key.
+        :params key: Key name.
+        :params default: Default value if key is not exist.
+        :returns: Value based on given key or default one.
+        """
+        result = self.all()
+        return result.get(key) or default
+
+    def set(self, key: str, value: Any, data: dict = None) -> bool:
+        """Set key with given value.
+
+        :params key: Key name.
+        :params value: Value of the key.
+        :params data full dictionary to push. Used in initial creation of config and secret
+        :returns: A ``bool`` to mark whether config is set or not.
+        """
+        all = self.all()
+        # Add the ability to inject the whole data dictionary at once. O
+        # therwise, a new version will be created for each secret.
+        if data:
+            all = {}
+            for k, v in data.items():
+                all[k] = safe_value(v)
+        else:
+            all[key] = safe_value(value)
+        secret = self.create_secret()
+        print(f'Size of secret payload : {sys.getsizeof(safe_value(all))} bytes')
+        secret_version_bool = self.add_secret_version(
+            self._encrypt(safe_value(all)))
+        return secret_version_bool
+
+    def create_secret(self) -> bool:
+        """
+        Create a new secret with the given name. A secret is a logical wrapper
+        around a collection of secret versions. Secret versions hold the actual
+        secret material.
+        """
+
+        # Build the resource name of the parent project.
+        parent = f"projects/{self.project_id}"
+        response = False
+        try:
+            # Create the secret.
+            response = self.client.create_secret(
+                request={
+                    "parent": parent,
+                    "secret_id": self.google_secret_name,
+                    "secret": {"replication": {"automatic": {}}},
+                }
+            )
+            # Print the new secret name.
+            print("Created secret: {}".format(response.name))
+
+        except AlreadyExists:
+            print(f'Secret {self.google_secret_name} already exists. A new version will be created.')
+
+        return bool(response)
+
+    def add_secret_version(self, payload: str) -> bool:
+        """
+        Add a new secret version to the given secret with the provided payload.
+        :params payload: encrypted payload
+        """
+
+        # Build the resource name of the parent secret.
+        parent = self.client.secret_path(self.project_id, self.google_secret_name)
+
+        # Convert the string payload into a bytes. This step can be omitted if you
+        # pass in bytes instead of a str for the payload argument.
+        payload = zlib.compress(payload.encode("UTF-8"))
+
+        # Add the secret version.
+        response = self.client.add_secret_version(
+            request={"parent": parent, "payload": {"data": payload}}
+        )
+
+        # Print the new secret version name.
+        print("Added secret version: {}".format(response.name))
+        return bool(response)
+
+    def delete(self) -> None:
+        """
+        Delete the secret with the given name and all of its versions.
+        """
+        # Build the resource name of the secret.
+        name = self.client.secret_path(self.project_id, self.google_secret_name)
+
+        try:
+            # Delete the secret.
+            self.client.delete_secret(request={"name": name})
+        except NotFound:
+            print(f'Secret {self.google_secret_name} does not exist in the secret manager.')

--- a/jans/pycloudlib/secret/google_secret.py
+++ b/jans/pycloudlib/secret/google_secret.py
@@ -34,18 +34,18 @@ class GoogleSecret(BaseSecret):
 
     - ``GOOGLE_APPLICATION_CREDENTIALS`` json file that should be injected in upstream images
     - ``GOOGLE_PROJECT_ID``
-    - ``CN_GOOGLE_SECRET_VERSION_ID``
+    - ``CN_SECRET_GOOGLE_SECRET_VERSION_ID``
     - ``CN_GOOGLE_SECRET_MANAGER_PASSPHRASE``
-    - ``CN_SECRET_GOOGLE_SECRET``
+    - ``CN_SECRET_GOOGLE_SECRET_NAME_PREFIX``
     """
 
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_PROJECT_ID")
-        self.version_id = os.getenv("CN_GOOGLE_SECRET_VERSION_ID", "latest")
+        self.version_id = os.getenv("CN_SECRET_GOOGLE_SECRET_VERSION_ID", "latest")
         self.salt = os.urandom(16)
         self.passphrase = os.getenv("CN_GOOGLE_SECRET_MANAGER_PASSPHRASE", "secret")
         # secrets key value by default
-        self.google_secret_name = os.getenv("CN_SECRET_GOOGLE_SECRET", "jans") + "-secret"
+        self.google_secret_name = os.getenv("CN_SECRET_GOOGLE_SECRET_NAME_PREFIX", "jans") + "-secret"
         # Create the Secret Manager client.
         self.client = secretmanager.SecretManagerServiceClient()
         self.key = self._set_key()

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         "docker>=3.7.2",
         "requests-toolbelt>=0.9.1",
         "cryptography>=2.8",
+        "google-cloud-secret-manager>=2.2.0"
+
     ],
     classifiers=[
         "Intended Audience :: Developers",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,10 +23,17 @@ def test_config_set(gconfig):
     assert "" in str(exc.value)
 
 
-def test_config_all(gconfig):
+def test_config_get_all(gconfig):
     with pytest.raises(NotImplementedError) as exc:
         gconfig.all()
     assert "" in str(exc.value)
+
+
+def test_config_set_all(gconfig):
+    with pytest.raises(NotImplementedError) as exc:
+        gconfig.set_all({})
+    assert "" in str(exc.value)
+
 
 # =============
 # consul config

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -11,6 +11,12 @@ class GAdapter(object):
     def all(self):
         return {}
 
+    def get_all(self):
+        return {}
+
+    def set_all(self, data):
+        return True
+
 
 @pytest.mark.parametrize("adapter, adapter_cls", [
     ("consul", "ConsulConfig"),

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -24,10 +24,17 @@ def test_secret_set(gsecret):
     assert "" in str(exc.value)
 
 
-def test_secret_all(gsecret):
+def test_secret_get_all(gsecret):
     with pytest.raises(NotImplementedError) as exc:
-        gsecret.all()
+        gsecret.get_all()
     assert "" in str(exc.value)
+
+
+def test_secret_set_all(gsecret):
+    with pytest.raises(NotImplementedError) as exc:
+        gsecret.set_all({})
+    assert "" in str(exc.value)
+
 
 
 # ============


### PR DESCRIPTION
This PR adds the ability to interact directly with google secret manager given the following is provided : 

Required Envs: 

`GOOGLE_PROJECT_ID` googles project id
`GOOGLE_APPLICATION_CREDENTIALS`  json file of service account that should be injected in upstream images

Optional Envs:
 
`CN_GOOGLE_SECRET_VERSION_ID` secrets version. Defaults to `latest`, which is recommended. 
`CN_GOOGLE_SECRET_MANAGER_PASSPHRASE` Any passphrase for encryption. This is recommended to be changed and defaults to `secret`
`CN_SECRET_GOOGLE_SECRET`. Prefix for secret in google secret manager. Defaults to `jans`. If left intact two secrets will be created `jans-secret` and `jans-configuration`. 

All other dependent images need to be updated to use this image. 
- Update `jans-pycloudlib` in `requirements.txt`
- Add `py3-grpcio` Alpine [package](https://pkgs.alpinelinux.org/package/edge/community/x86/py3-grpcio) to `DockerFile`. 

Example:

  ```DockerFile
     RUN apk update \
         && apk add --no-cache openssl py3-pip tini curl bash py3-grpcio openjdk11-jre-headless py3-cryptography \
         && apk add --no-cache --virtual build-deps wget git \
         && mkdir -p /usr/java/latest \
         && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
  ```
  
  unit tests has not been added to the initial commit. 