### PR TITLE
feat: encode/decode password file

### DIFF
--- a/jans/pycloudlib/__init__.py
+++ b/jans/pycloudlib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0-dev1"
+__version__ = "1.0-dev2"
 
 from jans.pycloudlib.manager import get_manager  # noqa: F401
 from jans.pycloudlib.wait import wait_for  # noqa: F401

--- a/jans/pycloudlib/cli/__init__.py
+++ b/jans/pycloudlib/cli/__init__.py
@@ -9,6 +9,7 @@ This module contains helper for CLI.
 import click
 
 from jans.pycloudlib.cli.encoding import decode_file
+from jans.pycloudlib.cli.encoding import decode_string
 
 
 @click.group(
@@ -19,3 +20,4 @@ def cli():
 
 
 cli.add_command(decode_file)
+cli.add_command(decode_string)

--- a/jans/pycloudlib/cli/__init__.py
+++ b/jans/pycloudlib/cli/__init__.py
@@ -1,0 +1,21 @@
+"""
+jans.pycloudlib.cli
+~~~~~~~~~~~~~~~~~~~
+
+This module contains helper for CLI.
+
+"""
+
+import click
+
+from jans.pycloudlib.cli.encoding import decode_file
+
+
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]}
+)
+def cli():
+    pass
+
+
+cli.add_command(decode_file)

--- a/jans/pycloudlib/cli/__init__.py
+++ b/jans/pycloudlib/cli/__init__.py
@@ -15,7 +15,7 @@ from jans.pycloudlib.cli.encoding import decode_string
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]}
 )
-def cli():
+def cli():  # pragma: no cover
     """Entrypoint of CLI commands.
     """
     pass

--- a/jans/pycloudlib/cli/__init__.py
+++ b/jans/pycloudlib/cli/__init__.py
@@ -16,6 +16,8 @@ from jans.pycloudlib.cli.encoding import decode_string
     context_settings={"help_option_names": ["-h", "--help"]}
 )
 def cli():
+    """Entrypoint of CLI commands.
+    """
     pass
 
 

--- a/jans/pycloudlib/cli/encoding.py
+++ b/jans/pycloudlib/cli/encoding.py
@@ -1,0 +1,53 @@
+"""
+jans.pycloudlib.cli.encoding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains CLI commands for encoding/decoding text.
+
+"""
+
+from binascii import Error as AsciiError
+
+import click
+
+from jans.pycloudlib import get_manager
+from jans.pycloudlib.utils import decode_text
+
+
+@click.command(help="Decode text from a file")
+@click.argument(
+    "path",
+    type=click.Path(True, resolve_path=True, allow_dash=True),
+)
+@click.option(
+    "--salt-file",
+    type=click.Path(True, resolve_path=True, allow_dash=True),
+    help="Read salt from file",
+)
+@click.option(
+    "--salt-literal",
+    help="Salt string (overrides salt from secrets/file)",
+)
+def decode_file(path, salt_file, salt_literal):
+    salt = ""
+    if salt_literal:
+        salt = salt_literal
+    elif salt_file:
+        with click.open_file(salt_file, "r") as f:
+            salt = f.read().split(" = ")[-1].strip()
+    else:
+        manager = get_manager()
+        try:
+            salt = manager.secret.get("encoded_salt")
+        except Exception as exc:  # noqa: B902
+            click.echo(f"Unable to get salt from secrets; reason={exc}")
+
+    if not salt:
+        raise click.Abort()
+
+    with click.open_file(path, "r") as f:
+        try:
+            txt = decode_text(f.read(), salt)
+            click.echo(txt)
+        except (AsciiError, ValueError) as exc:
+            click.echo(f"Unable to decode file {path}; reason={exc}")

--- a/jans/pycloudlib/cli/encoding.py
+++ b/jans/pycloudlib/cli/encoding.py
@@ -6,8 +6,6 @@ This module contains CLI commands for encoding/decoding text.
 
 """
 
-from binascii import Error as AsciiError
-
 import click
 
 from jans.pycloudlib import get_manager
@@ -49,7 +47,7 @@ def decode_file(path, salt_file, salt_literal):
         try:
             txt = decode_text(f.read(), salt)
             click.echo(txt)
-        except (AsciiError, ValueError) as exc:
+        except ValueError as exc:
             click.echo(f"Unable to decode file {path}; reason={exc}")
 
 
@@ -84,5 +82,5 @@ def decode_string(text, salt_file, salt_literal):
     try:
         txt = decode_text(text, salt)
         click.echo(txt)
-    except (AsciiError, ValueError) as exc:
+    except ValueError as exc:
         click.echo(f"Unable to decode given string; reason={exc}")

--- a/jans/pycloudlib/cli/encoding.py
+++ b/jans/pycloudlib/cli/encoding.py
@@ -48,7 +48,7 @@ def decode_file(path, salt_file, salt_literal):
             txt = decode_text(f.read(), salt)
             click.echo(txt)
         except ValueError as exc:
-            click.echo(f"Unable to decode file {path}; reason={exc}")
+            raise click.ClickException(f"Unable to decode file {path}; reason={exc}")
 
 
 @click.command(help="Decode text string")
@@ -83,4 +83,4 @@ def decode_string(text, salt_file, salt_literal):
         txt = decode_text(text, salt)
         click.echo(txt)
     except ValueError as exc:
-        click.echo(f"Unable to decode given string; reason={exc}")
+        raise click.ClickException(f"Unable to decode given string; reason={exc}")

--- a/jans/pycloudlib/cli/encoding.py
+++ b/jans/pycloudlib/cli/encoding.py
@@ -51,3 +51,38 @@ def decode_file(path, salt_file, salt_literal):
             click.echo(txt)
         except (AsciiError, ValueError) as exc:
             click.echo(f"Unable to decode file {path}; reason={exc}")
+
+
+@click.command(help="Decode text string")
+@click.argument("text")
+@click.option(
+    "--salt-file",
+    type=click.Path(True, resolve_path=True, allow_dash=True),
+    help="Read salt from file",
+)
+@click.option(
+    "--salt-literal",
+    help="Salt string (overrides salt from secrets/file)",
+)
+def decode_string(text, salt_file, salt_literal):
+    salt = ""
+    if salt_literal:
+        salt = salt_literal
+    elif salt_file:
+        with click.open_file(salt_file, "r") as f:
+            salt = f.read().split(" = ")[-1].strip()
+    else:
+        manager = get_manager()
+        try:
+            salt = manager.secret.get("encoded_salt")
+        except Exception as exc:  # noqa: B902
+            click.echo(f"Unable to get salt from secrets; reason={exc}")
+
+    if not salt:
+        raise click.Abort()
+
+    try:
+        txt = decode_text(text, salt)
+        click.echo(txt)
+    except (AsciiError, ValueError) as exc:
+        click.echo(f"Unable to decode given string; reason={exc}")

--- a/jans/pycloudlib/persistence/sql.py
+++ b/jans/pycloudlib/persistence/sql.py
@@ -5,31 +5,56 @@ jans.pycloudlib.persistence.sql
 This module contains various helpers related to SQL persistence.
 """
 
-import contextlib
+# import contextlib
 import logging
 import os
+from binascii import Error as AsciiError
 
 from sqlalchemy import create_engine
 from sqlalchemy import MetaData
 from sqlalchemy import func
 from sqlalchemy import select
 
+from jans.pycloudlib import get_manager
+from jans.pycloudlib.utils import decode_text
 from jans.pycloudlib.utils import encode_text
 
 logger = logging.getLogger(__name__)
 
 
-def get_sql_password() -> str:
+def get_sql_password(manager) -> str:
     """Get password used for SQL database user.
 
     :returns: Plaintext password.
     """
     password_file = os.environ.get("CN_SQL_PASSWORD_FILE", "/etc/jans/conf/sql_password")
-
     password = ""
-    with contextlib.suppress(FileNotFoundError):
-        with open(password_file) as f:
-            password = f.read().strip()
+
+    # get password
+    with open(password_file) as f:
+        password = f.read().strip()
+
+    # check if password is encoded; non-encoded and empty password will throw incorrect
+    # padding/bytes which will be handled by encoding the password;
+    # other errors will be thrown automatically by interpreter
+    salt = manager.secret.get("encoded_salt")
+    should_encode = False
+
+    try:
+        password = decode_text(password, salt).decode()
+    except AsciiError:
+        logger.warning(f"Current password in {password_file} is not encoded")
+        should_encode = True
+    except ValueError:
+        logger.warning(f"Got empty password in {password_file}")
+        should_encode = True
+
+    if should_encode:
+        logger.warning(f"Attempting to encode the password in {password_file}")
+        with open(password_file, "w") as f:
+            f.write(encode_text(password, salt).decode())
+
+    # returns plain password for compatibility
     return password
 
 
@@ -37,7 +62,8 @@ class BaseClient:
     """Base class for SQL client adapter.
     """
 
-    def __init__(self):
+    def __init__(self, manager):
+        self.manager = manager
         self.engine = create_engine(
             self.engine_url,
             pool_pre_ping=True,
@@ -254,7 +280,7 @@ class PostgresqlClient(BaseClient):
         port = os.environ.get("CN_SQL_DB_PORT", 5432)
         database = os.environ.get("CN_SQL_DB_NAME", "jans")
         user = os.environ.get("CN_SQL_DB_USER", "jans")
-        password = get_sql_password()
+        password = get_sql_password(self.manager)
         return f"{self.connector}://{user}:{password}@{host}:{port}/{database}"
 
     def on_create_table_error(self, exc):
@@ -311,7 +337,7 @@ class MysqlClient(BaseClient):
         port = os.environ.get("CN_SQL_DB_PORT", 3306)
         database = os.environ.get("CN_SQL_DB_NAME", "jans")
         user = os.environ.get("CN_SQL_DB_USER", "jans")
-        password = get_sql_password()
+        password = get_sql_password(self.manager)
         return f"{self.connector}://{user}:{password}@{host}:{port}/{database}"
 
     def on_create_table_error(self, exc):
@@ -363,12 +389,13 @@ class SQLClient:
         "server_version",
     )
 
-    def __init__(self):
+    def __init__(self, manager=None):
+        manager = manager or get_manager()
         dialect = os.environ.get("CN_SQL_DB_DIALECT", "mysql")
         if dialect in ("pgsql", "postgresql"):
-            self.adapter = PostgresqlClient()
+            self.adapter = PostgresqlClient(manager)
         elif dialect == "mysql":
-            self.adapter = MysqlClient()
+            self.adapter = MysqlClient(manager)
 
         self._adapter_methods = [
             method for method in dir(self.adapter)
@@ -404,7 +431,7 @@ def render_sql_properties(manager, src: str, dest: str) -> None:
             "rdbm_port": os.environ.get("CN_SQL_DB_PORT", 3306),
             "rdbm_user": os.environ.get("CN_SQL_DB_USER", "jans"),
             "rdbm_password_enc": encode_text(
-                get_sql_password(),
+                get_sql_password(manager),
                 manager.secret.get("encoded_salt"),
             ).decode(),
             "server_time_zone": os.environ.get("CN_SQL_DB_TIMEZONE", "UTC"),

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "sqlalchemy>=1.3,<1.4",
         "psycopg2>=2.8.6",
         "google-cloud-spanner>=3.3.0",
+        "Click>=6.7",
     ],
     classifiers=[
         "Intended Audience :: Developers",
@@ -56,4 +57,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     include_package_data=True,
+    entry_points={
+        "console_scripts": ["jans-pycloudlib=jans.pycloudlib.cli:cli"],
+    },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,154 @@
+from click.testing import CliRunner
+
+
+def test_encoding_decode_file_salt_literal():
+    from jans.pycloudlib.cli.encoding import decode_file
+
+    salt = "2CG9qwCzH5haWXXuUIUe4wFT"
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("password.txt", "w") as f:
+            f.write("4rl2tJEQFkY=")
+
+        result = runner.invoke(
+            decode_file,
+            ["password.txt", "--salt-literal", salt]
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == "secret"
+
+
+def test_encoding_decode_file_salt_file():
+    from jans.pycloudlib.cli.encoding import decode_file
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("password.txt", "w") as f:
+            f.write("4rl2tJEQFkY=")
+
+        with open("salt.txt", "w") as f:
+            f.write("2CG9qwCzH5haWXXuUIUe4wFT")
+
+        result = runner.invoke(
+            decode_file,
+            ["password.txt", "--salt-file", "salt.txt"]
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == "secret"
+
+
+def test_encoding_decode_file_salt(monkeypatch):
+    from jans.pycloudlib.cli.encoding import decode_file
+
+    monkeypatch.setattr(
+        "jans.pycloudlib.manager.SecretManager.get",
+        lambda key, default: "2CG9qwCzH5haWXXuUIUe4wFT",
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("password.txt", "w") as f:
+            f.write("4rl2tJEQFkY=")
+
+        result = runner.invoke(decode_file, ["password.txt"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "secret"
+
+
+def test_encoding_decode_file_no_salt():
+    from jans.pycloudlib.cli.encoding import decode_file
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("password.txt", "w") as f:
+            f.write("4rl2tJEQFkY=")
+
+        result = runner.invoke(decode_file, ["password.txt"])
+        assert result.exit_code == 1
+        assert "Aborted" in result.output.strip()
+
+
+def test_encoding_decode_file_value_error(monkeypatch):
+    from jans.pycloudlib.cli.encoding import decode_file
+
+    monkeypatch.setattr(
+        "jans.pycloudlib.manager.SecretManager.get",
+        lambda key, default: "2CG9qwCzH5haWXXuUIUe4wFT",
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("password.txt", "w") as f:
+            f.write("4rl2tJEQFkY")
+
+        result = runner.invoke(decode_file, ["password.txt"])
+        assert result.exit_code == 1
+        assert "Error:" in result.output.strip()
+
+
+def test_encoding_decode_string_salt_literal():
+    from jans.pycloudlib.cli.encoding import decode_string
+
+    salt = "2CG9qwCzH5haWXXuUIUe4wFT"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        decode_string,
+        ["4rl2tJEQFkY=", "--salt-literal", salt],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "secret"
+
+
+def test_encoding_decode_string_salt_file():
+    from jans.pycloudlib.cli.encoding import decode_string
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("salt.txt", "w") as f:
+            f.write("2CG9qwCzH5haWXXuUIUe4wFT")
+
+        result = runner.invoke(
+            decode_string,
+            ["4rl2tJEQFkY=", "--salt-file", "salt.txt"],
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == "secret"
+
+
+def test_encoding_decode_string_salt(monkeypatch):
+    from jans.pycloudlib.cli.encoding import decode_string
+
+    monkeypatch.setattr(
+        "jans.pycloudlib.manager.SecretManager.get",
+        lambda key, default: "2CG9qwCzH5haWXXuUIUe4wFT",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(decode_string, ["4rl2tJEQFkY="])
+    assert result.exit_code == 0
+    assert result.output.strip() == "secret"
+
+
+def test_encoding_decode_string_no_salt():
+    from jans.pycloudlib.cli.encoding import decode_string
+
+    runner = CliRunner()
+    result = runner.invoke(decode_string, ["4rl2tJEQFkY="])
+    assert result.exit_code == 1
+    assert "Aborted" in result.output.strip()
+
+
+def test_encoding_decode_string_value_error(monkeypatch):
+    from jans.pycloudlib.cli.encoding import decode_string
+
+    monkeypatch.setattr(
+        "jans.pycloudlib.manager.SecretManager.get",
+        lambda key, default: "2CG9qwCzH5haWXXuUIUe4wFT",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(decode_string, ["4rl2tJEQFkY"])
+    assert result.exit_code == 1
+    assert "Error:" in result.output.strip()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -145,15 +145,9 @@ def test_get_couchbase_password(monkeypatch, tmpdir, gmanager):
     monkeypatch.setenv("CN_COUCHBASE_PASSWORD_FILE", str(passwd_file))
     assert get_couchbase_password(gmanager) == "secret"
 
-
-def test_get_encoded_couchbase_password(monkeypatch, tmpdir, gmanager):
-    from jans.pycloudlib.persistence.couchbase import get_encoded_couchbase_password
-
-    passwd_file = tmpdir.join("couchbase_password")
-    passwd_file.write("secret")
-
-    monkeypatch.setenv("CN_COUCHBASE_PASSWORD_FILE", str(passwd_file))
-    assert get_encoded_couchbase_password(gmanager) != "secret"
+    # ensure the password file is modified (having encoded password)
+    with open(str(passwd_file)) as f:
+        assert f.read() == "fHL54sT5qHk="
 
 
 def test_get_couchbase_superuser(monkeypatch, gmanager):
@@ -171,16 +165,6 @@ def test_get_couchbase_superuser_password(monkeypatch, tmpdir, gmanager):
 
     monkeypatch.setenv("CN_COUCHBASE_SUPERUSER_PASSWORD_FILE", str(passwd_file))
     assert get_couchbase_superuser_password(gmanager) == "secret"
-
-
-def test_get_encoded_couchbase_superuser_password(monkeypatch, tmpdir, gmanager):
-    from jans.pycloudlib.persistence.couchbase import get_encoded_couchbase_superuser_password
-
-    passwd_file = tmpdir.join("couchbase_superuser_password")
-    passwd_file.write("secret")
-
-    monkeypatch.setenv("CN_COUCHBASE_SUPERUSER_PASSWORD_FILE", str(passwd_file))
-    assert get_encoded_couchbase_superuser_password(gmanager) != "secret"
 
 
 @pytest.mark.skipif(
@@ -521,15 +505,18 @@ storage.couchbase.mapping: people, groups, authorizations, cache, tokens, sessio
 # ===
 
 
-def test_get_sql_password(monkeypatch, tmpdir):
+def test_get_sql_password(monkeypatch, tmpdir, gmanager):
     from jans.pycloudlib.persistence.sql import get_sql_password
 
     src = tmpdir.join("sql_password")
     src.write("secret")
-
     monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
 
-    assert get_sql_password() == "secret"
+    assert get_sql_password(gmanager) == "secret"
+
+    # ensure the password file is modified (having encoded password)
+    with open(str(src)) as f:
+        assert f.read() == "fHL54sT5qHk="
 
 
 def test_render_sql_properties(monkeypatch, tmpdir, gmanager):
@@ -568,30 +555,42 @@ auth.userPassword=fHL54sT5qHk=
     "mysql",
     "pgsql",
 ])
-def test_sql_client_init(monkeypatch, dialect):
+def test_sql_client_init(monkeypatch, dialect, gmanager, tmpdir):
     from jans.pycloudlib.persistence.sql import SQLClient
 
     monkeypatch.setenv("CN_SQL_DB_DIALECT", dialect)
 
-    client = SQLClient()
+    src = tmpdir.join("sql_password")
+    src.write("secret")
+    monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
+
+    client = SQLClient(gmanager)
     assert client.adapter.dialect == dialect
 
 
-def test_sql_client_getattr(monkeypatch):
+def test_sql_client_getattr(monkeypatch, gmanager, tmpdir):
     from jans.pycloudlib.persistence.sql import SQLClient
 
     monkeypatch.setenv("CN_SQL_DB_DIALECT", "mysql")
 
-    client = SQLClient()
+    src = tmpdir.join("sql_password")
+    src.write("secret")
+    monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
+
+    client = SQLClient(gmanager)
     assert client.__getattr__("create_table")
 
 
-def test_sql_client_getattr_error(monkeypatch):
+def test_sql_client_getattr_error(monkeypatch, gmanager, tmpdir):
     from jans.pycloudlib.persistence.sql import SQLClient
 
     monkeypatch.setenv("CN_SQL_DB_DIALECT", "mysql")
 
-    client = SQLClient()
+    src = tmpdir.join("sql_password")
+    src.write("secret")
+    monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
+
+    client = SQLClient(gmanager)
     with pytest.raises(AttributeError):
         assert client.__getattr__("random_attr")
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -141,13 +141,8 @@ def test_get_couchbase_password(monkeypatch, tmpdir, gmanager):
 
     passwd_file = tmpdir.join("couchbase_password")
     passwd_file.write("secret")
-
     monkeypatch.setenv("CN_COUCHBASE_PASSWORD_FILE", str(passwd_file))
     assert get_couchbase_password(gmanager) == "secret"
-
-    # ensure the password file is modified (having encoded password)
-    with open(str(passwd_file)) as f:
-        assert f.read() == "fHL54sT5qHk="
 
 
 def test_get_couchbase_superuser(monkeypatch, gmanager):
@@ -511,12 +506,7 @@ def test_get_sql_password(monkeypatch, tmpdir, gmanager):
     src = tmpdir.join("sql_password")
     src.write("secret")
     monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
-
     assert get_sql_password(gmanager) == "secret"
-
-    # ensure the password file is modified (having encoded password)
-    with open(str(src)) as f:
-        assert f.read() == "fHL54sT5qHk="
 
 
 def test_render_sql_properties(monkeypatch, tmpdir, gmanager):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -253,3 +253,19 @@ def test_generate_signed_ssl_certkey(tmpdir):
     assert os.path.isfile(str(base_dir.join("my-suffix.crt")))
     assert os.path.isfile(str(base_dir.join("my-suffix.csr")))
     assert os.path.isfile(str(base_dir.join("my-suffix.key")))
+
+
+@pytest.mark.parametrize("password, encoded_password", [
+    ("secret", "fHL54sT5qHk="),
+    ("", "U7niJiK7IV8="),
+])
+def test_secure_password_file(tmpdir, password, encoded_password):
+    from jans.pycloudlib.utils import secure_password_file
+
+    src = tmpdir.join("password_file")
+    src.write(password)
+    salt = "7MEDWVFAG3DmakHRyjMqp5EE"
+    assert secure_password_file(str(src), salt) == password
+
+    with open(str(src)) as f:
+        assert f.read() == encoded_password


### PR DESCRIPTION
Overview:

- added automatic migration of plain password in password files (ie `sql_password`, `couchbase_password`) into encoded password
- added CLI to read encoded password files (run `jans-pycloudlib -h` command to see details)