### PR TITLE
fix: handle non-writable password file

### DIFF
--- a/jans/pycloudlib/utils.py
+++ b/jans/pycloudlib/utils.py
@@ -469,8 +469,11 @@ def secure_password_file(password_file, salt):
 
     if should_encode:
         logger.warning(f"Attempting to encode the password in {password_file}")
-        with open(password_file, "w") as f:
-            f.write(encode_text(password, salt).decode())
+        try:
+            with open(password_file, "w") as f:
+                f.write(encode_text(password, salt).decode())
+        except Exception as exc:  # noqa: B902
+            logger.warning(f"Unable to encode the password in {password_file}; reason={exc}")
 
     # returns plain password for compatibility
     return password

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -269,3 +269,21 @@ def test_secure_password_file(tmpdir, password, encoded_password):
 
     with open(str(src)) as f:
         assert f.read() == encoded_password
+
+
+@pytest.mark.parametrize("password, encoded_password", [
+    ("secret", "secret"),
+])
+def test_secure_password_file_non_writable(tmpdir, password, encoded_password):
+    import stat
+    from jans.pycloudlib.utils import secure_password_file
+
+    src = tmpdir.join("password_file")
+    src.write(password)
+    # make READONLY file to test fallback
+    src.chmod(stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+    salt = "7MEDWVFAG3DmakHRyjMqp5EE"
+    assert secure_password_file(str(src), salt) == password
+
+    with open(str(src)) as f:
+        assert f.read() == encoded_password


### PR DESCRIPTION
Overview:

- added try-catch to handle non-writable password file error during automatic conversion of password